### PR TITLE
fix: move dev storage to global config

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -54,6 +54,13 @@ async function main() {
             route: '/**',
           },
         ],
+        bundledStorage: ['templates'],
+        devStorage: {
+          templates: {
+            driver: 'fs',
+            base: '.nitro/templates',
+          },
+        },
         devHandlers: [
           {
             route: '/__vite',
@@ -100,13 +107,6 @@ async function main() {
     const nitro = await createNitro({
       rootDir,
       dev: false,
-      bundledStorage: ['templates'],
-      devStorage: {
-        templates: {
-          driver: 'fs',
-          base: '.nitro/templates',
-        },
-      },
       ...(config.nitro ?? {}),
     })
     await prepare(nitro)


### PR DESCRIPTION
Hello,

I was looking to understand your talk (and I rebuild it with vue) but I see that in dev mode, storage does not have the templates key.

In nitro, you use dev storage only in the build config. I move it to the global storage.